### PR TITLE
2023/03/16

### DIFF
--- a/src/main/java/com/weasy/user/board/controller/BoardAjaxController.java
+++ b/src/main/java/com/weasy/user/board/controller/BoardAjaxController.java
@@ -48,6 +48,12 @@ public class BoardAjaxController {
 //		return null;
 	}
 	
+	@PostMapping("/getTeamInfo")
+	@ResponseBody
+	public TeamVO getTeamInfo(@RequestBody TeamVO vo) {
+		return boardService.getTeamInfo(vo);
+	}
+	
 	//팀 선택 시 그 해당하는 팀의 task불러오기
 	@PostMapping("/getTeamTask")
 	@ResponseBody

--- a/src/main/java/com/weasy/user/board/controller/BoardController.java
+++ b/src/main/java/com/weasy/user/board/controller/BoardController.java
@@ -45,19 +45,25 @@ public class BoardController {
 	public String addTeam(TeamVO vo,
 						  RedirectAttributes ra) {
 		
-		int result = boardService.insertTeam(vo);
 		int teamNo = boardService.getTeamNo(vo.getTeamName());
-		
 		//해당 팀no로 지정한 teamLeader 권한 주기
 		AuthorityVO authVO = AuthorityVO.builder().userEmail(vo.getUserEmail())
 							 .teamNo(teamNo)
 							 .role(0)
 							 .build();
-		boardService.addAuthority(authVO);
+		int result = 0;
+		if(vo.getTeamNo() != 0) {
+			/* 기존에 있는 팀이라면 update & 권한도 업데이트 teamLeader가 변경되었을수 있으므로 */
+			result = boardService.updateTeam(vo);
+			boardService.updateAuthority(authVO);
+		}else {
+			/* 기존에 없는 팀이면 insertTeam & teamLeader에 권한 insert */
+			result = boardService.insertTeam(vo);
+			boardService.addAuthority(authVO);
+		}
 		
 		String msg = result == 1 ? "정상 입력되었습니다" : "등록에 실패했습니다";
 		ra.addFlashAttribute("msg", msg);
-		
 		return "redirect:/board/board";
 	}
 	

--- a/src/main/java/com/weasy/user/board/service/BoardMapper.java
+++ b/src/main/java/com/weasy/user/board/service/BoardMapper.java
@@ -18,12 +18,18 @@ public interface BoardMapper {
 	/* 팀 */
 	public int insertTeam(TeamVO vo);
 	
+	/* 팀 update */
+	public int updateTeam(TeamVO vo);
+	
 	public ArrayList<TeamVO> getTeamList(String user_id);
 	
 	//user가 속한 팀 리스트와 권한을 함께 가지고 온다.
 	public ArrayList<TeamVO> getTeamListWithRole(String user_id);
 	
 	public int getTeamNo(String teamName);
+	
+	//선택한 팀 정보 읽어오기
+	public TeamVO getTeamInfo(TeamVO vo);
 	
 	//현재 팀에 추가되어있는 멤버 권한 리스트 가져오기
 	public ArrayList<AuthorityVO> getTeamMember(TeamVO vo);

--- a/src/main/java/com/weasy/user/board/service/BoardService.java
+++ b/src/main/java/com/weasy/user/board/service/BoardService.java
@@ -13,12 +13,18 @@ public interface BoardService {
 	/* 팀 */
 	public int insertTeam(TeamVO vo);
 	
+	/* 팀 update */
+	public int updateTeam(TeamVO vo);
+	
 	public ArrayList<TeamVO> getTeamList(String user_id);
 	
 	//user가 속한 팀 리스트와 권한을 함께 가지고 온다.
 	public ArrayList<TeamVO> getTeamListWithRole(String user_id);
 	
 	public int getTeamNo(String teamName);
+	
+	//선택한 팀 정보 읽어오기
+	public TeamVO getTeamInfo(TeamVO vo);
 	
 	//현재 팀에 추가되어있는 멤버 권한 리스트 가져오기
 	public ArrayList<AuthorityVO> getTeamMember(TeamVO vo);

--- a/src/main/java/com/weasy/user/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/weasy/user/board/service/BoardServiceImpl.java
@@ -21,10 +21,18 @@ public class BoardServiceImpl implements BoardService{
 	
 	@Override
 	public int insertTeam(TeamVO vo) {
-		
 		System.out.println("서비스" + vo.toString());
-		
 		return boardMapper.insertTeam(vo);
+	}
+	
+	@Override
+	public int updateTeam(TeamVO vo) {
+		return boardMapper.updateTeam(vo);
+	}
+	
+	@Override
+	public TeamVO getTeamInfo(TeamVO vo) {
+		return boardMapper.getTeamInfo (vo);
 	}
 	
 	@Override

--- a/src/main/resources/mapper/BoardMapper.xml
+++ b/src/main/resources/mapper/BoardMapper.xml
@@ -21,9 +21,24 @@
   						   #{teamStatus})
   	</insert>	
   	
+  	<update id="updateTeam" parameterType="TeamVO">
+  		update team set
+  			teamRegdate=#{teamRegdate},
+  			endDate=#{endDate},
+  			teamGoal=#{teamGoal},
+  			userEmail=#{userEmail}
+  		where teamNo = #{teamNo}
+  	</update>
+  	
   	<select id="getTeamList" resultType="TeamVO">
   		select teamNo, teamRegdate, endDate, teamName, teamGoal, userEmail, teamStatus 
   		from TEAM where teamNo IN (select teamNo from authority where userEmail=#{userEmail}) and t.teamStatus = 'Y'
+  		order by teamNo asc
+  	</select>
+  	
+  	<select id="getTeamInfo" resultType="TeamVO">
+  		select teamNo, teamRegdate, endDate, teamName, teamGoal, userEmail, teamStatus 
+  		from team where teamNo=#{teamNo};
   	</select>
   	
   	<update id="closeTeamStatus">
@@ -36,10 +51,10 @@
 		left join authority a
 		on t.teamNo = a.teamNo
 		where a.userEmail = #{userEmail} and t.teamStatus = 'Y'
+		order by teamNo asc
   	</select>
   	
   	<insert id="addTask" parameterType="TaskVO">
-  	
   		insert into task(title,
   						 content,
   						 startDate,
@@ -52,7 +67,6 @@
   						   #{targetDate},
   						   #{teamNo},
   						   0)
-  						   
   	</insert>
   	
   	<select id="getTaskList" resultType="TaskVO">

--- a/src/main/resources/static/css/modal.css
+++ b/src/main/resources/static/css/modal.css
@@ -165,7 +165,7 @@
 	margin-right: 5px;
 }
 
-.hidden{
+.hiddenBtn{
 	display: none;
 }
 
@@ -524,6 +524,10 @@
     background: url(https://freepikpsd.com/media/2019/10/down-arrow-icon-png-7-Transparent-Images.png) calc(100% - 7px) center no-repeat;
     color:white;
     font-size: 13px;
+}
+
+.chooseMemberList select option {
+	color:black;
 }
 
 ::-webkit-input-placeholder {

--- a/src/main/resources/static/css/weasy.css
+++ b/src/main/resources/static/css/weasy.css
@@ -34,6 +34,7 @@ html {
     overflow: hidden;
     margin: 10px 0px;
 }
+
 .profile {
     width: 100%;
     height: 100%;
@@ -338,6 +339,7 @@ menu {
   font-size: 14px;
   line-height: 15px;
   display: none;
+  width: 220px;
 }
 
 menu::before {
@@ -360,6 +362,7 @@ menu hr {
   background: rgba(0, 0, 0, 0.10);
   margin: 6px 1px 5px;
   padding: 0;
+  width: 220px;
 }
 
 menu menuitem {
@@ -549,22 +552,16 @@ section.notice {
 
 /* reset */
 
-* {
-  list-style: none;
-  text-decoration: none;
-  padding: 0;
-  margin: 0;
-  box-sizing: border-box;
-}
 .clearfix:after {
   content: '';
   display: block;
   clear: both;
 }
-.container {
+.notice-container {
   width: 1100px;
   margin: 0 auto;
 }
+
 .blind {
   position: absolute;
   overflow: hidden;
@@ -605,7 +602,7 @@ section.notice {
 	color: #ABB2B9;
 	cursor: pointer;
 	transition: background .2s ease, color .2s ease;
-	width: 300px;
+	width: 310px;
 	text-align: center;
 }
 

--- a/src/main/resources/templates/board/board.html
+++ b/src/main/resources/templates/board/board.html
@@ -186,7 +186,9 @@
 <!-- 팀 목록에 대한 context menu  -->
 <menu type="context" class="contextMenu" id="menu">
   <menuitem label="add Team/Project Member"></menuitem>
-  <hr>
+  <hr/>
+  <menuitem label="edit Team/Project"></menuitem>
+  <hr/>
   <menuitem label="Delete Team/Project"></menuitem>
 </menu>
 <!-- 팀 목록에 대한 context menu 끝 -->

--- a/src/main/resources/templates/modal/taskCard.html
+++ b/src/main/resources/templates/modal/taskCard.html
@@ -25,7 +25,7 @@
 				
 				<button type="button" class="button-prevent addMember">
 					<i data-feather="user" class="addMember"></i>
-					<i id="plusBtn" data-feather="plus-square" class="hidden addMember"></i>
+					<i id="plusBtn" data-feather="plus-square" class="hiddenBtn addMember"></i>
 					<span id="taskuser" class="addMember"></span>
 				</button>
 				

--- a/src/main/resources/templates/modal/teamProjectAdd.html
+++ b/src/main/resources/templates/modal/teamProjectAdd.html
@@ -2,6 +2,7 @@
 
 	<!-- 팀/프로젝트 추가 모달창 -->
 	<form action="addTeam" method="post">
+		
 		<div class="modal" id="modal">
 			<div class="modal_body">
 				<div class="m_head">
@@ -12,6 +13,8 @@
 				</div>
 
 				<div class="m_body">
+					<input type="hidden" id="teamNo" name="teamNo" value="0">
+					
 					<!-- 팀생성일 ~ 팀 종료일 -->
 					<div class="m_date">
 						<p class="p">start date</p>


### PR DESCRIPTION
모든 모달창들 close시 입력된 정보 초기화 & 팀 리스트 만든 순서대로
가져오도록 수정 & 팀 정보 수정 기능 추가

1. 모달창 닫힐 때 모든 정보 초기화 되도록 수정 (팀 추가, 팀 수정, task card모달창)
	- 팀원 추가는 기존에 잘 초기화되어 동작하고 있었음.
2. 팀 리스트 팀이 만들어진 순서대로 리스트가 뜨도록 수정하였습니다.
	- mapper에서 where 조건 추가 (getTeamList, getTeamListWithRole)
3. context menu에 edit Team/Project 메뉴 추가
	- 클릭하면 해당 팀의 정보를 긁어와서 모달창에 뿌려주고 수정하여 반영할 수 있다.